### PR TITLE
feat: subviewer has explicit triangle and quad modes

### DIFF
--- a/subdivide/examples/subviewer.cpp
+++ b/subdivide/examples/subviewer.cpp
@@ -65,18 +65,20 @@ void init(int argc, char** argv, bool& triMode, TagIvGraph& ivGraph) {
     const char* inputFile = nullptr;
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--mode") == 0) {
-            if (i + 1 < argc) {
-                const char* modeArg = argv[i+1];
-                if (strcmp(modeArg, "tri") == 0 || strcmp(modeArg, "triangle") == 0) {
-                    triMode = true;
-                } else if (strcmp(modeArg, "quad") == 0 || strcmp(modeArg, "quadrilateral") == 0) {
-                    triMode = false;
-                } else {
-                    std::cerr << "Invalid mode: " << modeArg << std::endl;
-                    exit(1);
-                }
-                i++; // Consumed mode argument value
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --mode requires an argument (tri|quad)" << std::endl;
+                exit(1);
             }
+            const char* modeArg = argv[i+1];
+            if (strcmp(modeArg, "tri") == 0) {
+                triMode = true;
+            } else if (strcmp(modeArg, "quad") == 0) {
+                triMode = false;
+            } else {
+                std::cerr << "Error: invalid mode '" << modeArg << "' (must be 'tri' or 'quad')" << std::endl;
+                exit(1);
+            }
+            i++; // Consumed mode argument value
         } else if (!inputFile) {
             // The first non-option argument is the input file
             inputFile = argv[i];

--- a/subdivide/examples/subviewer.cpp
+++ b/subdivide/examples/subviewer.cpp
@@ -482,8 +482,7 @@ void registerQuadCB(PickViewer* quadViewer, PickableQuad* quadObject) {
 //-----------------------------------------------------------------------------
 
 int main(int argc, char** argv) {
-
-    const char* mode = "tri"; // Default to showing both viewers
+    bool triMode = true;
 
     // Parse command-line arguments for --mode
     for (int i = 1; i < argc; ++i) {
@@ -491,9 +490,9 @@ int main(int argc, char** argv) {
             if (i + 1 < argc) {
                 const char* modeArg = argv[i+1];
                 if (strcmp(modeArg, "tri") == 0 || strcmp(modeArg, "triangle") == 0) {
-                    mode = "tri";
+                    triMode = true;
                 } else if (strcmp(modeArg, "quad") == 0 || strcmp(modeArg, "quadrilateral") == 0) {
-                    mode = "quad";
+                    triMode = false;
                 } // else: invalid mode, stick to default "tri"
                 i++; // Consumed mode argument value
             }
@@ -517,15 +516,13 @@ int main(int argc, char** argv) {
     triObject.getMesh().subdivide(0);
     quadObject.getMesh().subdivide(0);
 
-    if (strcmp(mode, "tri") == 0) {
-        PickViewer* triViewer = nullptr;
-        triViewer = new PickViewer("triViewer");
+    if (triMode) {
+        PickViewer* triViewer = new PickViewer("Subdivide 2.0 :: Triangles");
         triViewer->setObject(&triObject);
         triViewer->setPos(100, 100);
         registerTriCB(triViewer, &triObject);
-    } else if (strcmp(mode, "quad") == 0) {
-        PickViewer* quadViewer = nullptr;
-        quadViewer = new PickViewer("quadViewer");
+    } else {
+        PickViewer* quadViewer = new PickViewer("Subdivide 2.0 :: Quads");
         quadViewer->setObject(&quadObject);
         quadViewer->setPos(50, 50);
         registerQuadCB(quadViewer, &quadObject);

--- a/subdivide/examples/subviewer.cpp
+++ b/subdivide/examples/subviewer.cpp
@@ -48,7 +48,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "trimanipulator.hpp"  // manipulation of triangles
 
 #include "sectorinfo.hpp" // sector information used for call backs
-#include <cstring> // For strcmp
+
+#include <cstring>
 
 int depth = 3;
 

--- a/subdivide/examples/subviewer.cpp
+++ b/subdivide/examples/subviewer.cpp
@@ -70,7 +70,7 @@ void init(int argc, char** argv, bool& triMode, TagIvGraph& ivGraph) {
                 std::cerr << "Error: --mode requires an argument (tri|quad)" << std::endl;
                 exit(1);
             }
-            const char* modeArg = argv[i+1];
+            const char* modeArg = argv[i + 1];
             if (strcmp(modeArg, "tri") == 0) {
                 triMode = true;
             } else if (strcmp(modeArg, "quad") == 0) {


### PR DESCRIPTION
The example `subviewer` now takes a `--mode` command-line argument, with valid settings `tri` and `quad`. The default is `tri`. Only one window is opened, for the selected mode.